### PR TITLE
Only expose frontend container port

### DIFF
--- a/backend/src/db/db.py
+++ b/backend/src/db/db.py
@@ -1,3 +1,4 @@
+import os
 import time
 from datetime import datetime, timezone
 
@@ -16,7 +17,7 @@ from sqlalchemy.exc import OperationalError
 # -----------------------#
 # Configuration
 # -----------------------#
-DATABASE_URL = "postgresql://taskuser:taskpass@procrastinationbuddy-db:5432/tasks"
+DATABASE_URL = f"postgresql://{os.getenv("POSTGRES_USER")}:{os.getenv("POSTGRES_PASSWORD")}@{os.getenv("POSTGRES_HOST")}:{os.getenv("POSTGRES_PORT")}/{os.getenv("POSTGRES_DB")}"
 DB_NAME_TASKS = "tasks"
 DB_NAME_SETTINGS = "settings"
 MAX_RETRIES = 120

--- a/backend/src/routes/tasks.py
+++ b/backend/src/routes/tasks.py
@@ -1,3 +1,4 @@
+import os
 from flask import Blueprint, request, jsonify
 from services.tasks import (
     generate_task,
@@ -8,7 +9,7 @@ from services.tasks import (
 )
 
 tasks_bp = Blueprint("tasks", __name__)
-OLLAMA_URL = "http://ollama:11434"
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://ollama:11434")
 
 
 @tasks_bp.route("/tasks", methods=["POST"])

--- a/buddy.sh
+++ b/buddy.sh
@@ -15,13 +15,15 @@ case "$1" in
     docker compose up --build --force-recreate --detach
 
     echo "Waiting for Ollama to be ready..."
-    until curl -s http://localhost:11434 | grep -q "Ollama is running"; do
+    until docker exec procrastinationbuddy-backend sh -c  'wget -qO- http://procrastinationbuddy-ollama:11434 | grep -q "Ollama is running"'; do
       echo -n "."
       sleep 1
     done
 
     echo "Downloading initial model (llama3:8b)..."
-    curl -s -X POST http://localhost:11434/api/pull -d '{"name": "llama3:8b"}'
+    docker exec procrastinationbuddy-backend sh -c "
+      wget --post-data='{\"name\": \"llama3:8b\"}' --header='Content-Type: application/json' -qO- http://procrastinationbuddy-ollama:11434/api/pull
+    "
 
     echo -e "\033[0;32m##################################\033[0m"
     echo -e "\033[0;32mAccess UI at http://localhost:8501\033[0m"

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,8 +2,6 @@ services:
   ollama:
     image: ollama/ollama
     container_name: procrastinationbuddy-ollama
-    ports:
-      - "11434:11434"
     volumes:
       - ./.volumes/ollama:/root/.ollama
 
@@ -16,8 +14,6 @@ services:
       POSTGRES_DB: tasks
     volumes:
       - ./.volumes/db:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
 
   backend:
     build:
@@ -27,8 +23,13 @@ services:
     depends_on:
       - ollama
       - db
-    ports:
-      - "5000:5000"
+    environment:
+      POSTGRES_USER: taskuser
+      POSTGRES_PASSWORD: taskpass
+      POSTGRES_DB: tasks
+      POSTGRES_HOST: procrastinationbuddy-db
+      POSTGRES_PORT: 5432
+      OLLAMA_URL: http://procrastinationbuddy-ollama:11434
 
   frontend:
     build:
@@ -39,3 +40,5 @@ services:
       - backend
     ports:
       - "8501:8501"
+    environment:
+      BACKEND_URL: http://procrastinationbuddy-backend:5000


### PR DESCRIPTION
## Summary

It's not necessary to expose Ollama, the database and the backend on the host machine. They can talk to each other within the docker network. Only the frontend needs to be exposed.

## Changes Made

- configure backend DB address using environment variables defined in compose file
- configure backend Ollama address using environment variables defined in compose file
- because the Ollama container is not exposed on localhost anymore, it must be initialized from within the docker network, e.g. by having the backend container use `wget` (`curl` is unfortunately not available in the backend container)

## Related Issue

<!-- Link to the related issue if any -->
