### PR TITLE
workflow must fail on bruno errors

### DIFF
--- a/.github/workflows/quality-gate.yaml
+++ b/.github/workflows/quality-gate.yaml
@@ -68,9 +68,12 @@ jobs:
           dockerfile: ./frontend/Dockerfile
           ignore: DL3018
 
-      - name: Run API and E2E Tests
+      - name: Start Buddy
         run: |
           ./buddy.sh start
+
+      - name: Run API and E2E Tests
+        run: |
           ./buddy.sh test
 
       - name: Publish Playwright Test Results

--- a/buddy.sh
+++ b/buddy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+#set -e
 
 case "$1" in
   start)
@@ -41,7 +41,13 @@ case "$1" in
     echo "Running API-Tests..."
     pushd tests/api
     ./npmw ci
-    ./npmw run bruno
+    output=$(./npmw run bruno)
+    echo "$output"
+    if echo "$output" | grep -qE "Requests:.*([1-9][0-9]*\s+failed|[1-9][0-9]*\s+error)"; then
+      echo "❌ Bruno tests failed: Requests had failures or errors"
+      exit 1
+    fi
+    echo "✅ Bruno tests passed"
     popd
 
     echo "Running E2E-Tests..."

--- a/buddy.sh
+++ b/buddy.sh
@@ -41,7 +41,7 @@ case "$1" in
     echo "Running API-Tests..."
     pushd tests/api
     ./npmw ci
-    output=$(./npmw run bruno)
+    output=$(./npmw run bruno) # Bruno returns 0 even if it fails under certain conditions (e.g. not able to resolve hosts)
     echo "$output"
     if echo "$output" | grep -qE "Requests:.*([1-9][0-9]*\s+failed|[1-9][0-9]*\s+error)"; then
       echo "❌ Bruno tests failed: Requests had failures or errors"

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,6 +4,8 @@ services:
     container_name: procrastinationbuddy-ollama
     volumes:
       - ./.volumes/ollama:/root/.ollama
+    ports:
+      - "11434:11434"
 
   db:
     image: postgres:17
@@ -30,6 +32,8 @@ services:
       POSTGRES_HOST: procrastinationbuddy-db
       POSTGRES_PORT: 5432
       OLLAMA_URL: http://procrastinationbuddy-ollama:11434
+    ports:
+      - "5000:5000"
 
   frontend:
     build:


### PR DESCRIPTION
Really funny. What seems to be working on Windows and MacOS, fails on Linux/Ubuntu. Bruno always returns 1 locally for me. But the Github actions returns 0 even though it fails. I was not able to find a specific config for this behavior. Maybe it detects Github and changes its behavior. But I couldn't turn it off if it exists. So parsing the log seems to be a valid option, too.