### PR TITLE
Add github-actions ecosystem to dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -62,3 +62,12 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Adds a `github-actions` package-ecosystem entry to `.github/dependabot.yaml` so workflow action versions in `.github/workflows/` get monthly dependency updates, grouped like the other ecosystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)