### PR TITLE
Docker/deployment hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy to .env and adjust as needed. All variables have safe defaults for
+# local development (see compose.yaml), so this file is only needed if you
+# want to override them (e.g. for anything beyond local dev).
+POSTGRES_USER=taskuser
+POSTGRES_PASSWORD=taskpass
+POSTGRES_DB=tasks

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .volumes/
 .DS_Store
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,8 +5,11 @@ COPY pyproject.toml pyproject.toml
 COPY uv.lock uv.lock
 
 RUN apk add --no-cache build-base
-RUN pip install --no-cache-dir uv==0.11.26 && uv sync
+RUN pip install --no-cache-dir uv==0.11.26 && uv sync --no-dev
 
 COPY src/ ./src/
 
-ENTRYPOINT [ "uv", "run", "src/app.py" ]
+RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
+USER app
+
+ENTRYPOINT [ "uv", "run", "--no-dev", "gunicorn", "--chdir", "src", "--bind", "0.0.0.0:5001", "app:app" ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,13 +6,15 @@ requires-python = ">=3.13"
 
 dependencies = [
     "flask>=3.1.2,<4.0.0",
+    "gunicorn>=23.0.0,<24.0.0",
     "psycopg2-binary>=2.9.12,<3.0.0",
-    "pytest>=9.1.1,<10.0.0",
     "requests>=2.34.2,<3.0.0",
-    "ruff>=0.15.20,<1.0.0",
     "sqlalchemy>=2.0.51,<3.0.0",
     "greenlet>=3.5.3,<4.0.0",
 ]
+
+[dependency-groups]
+dev = ["pytest>=9.1.1,<10.0.0", "ruff>=0.15.20,<1.0.0"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/backend/src/db/db.py
+++ b/backend/src/db/db.py
@@ -22,6 +22,7 @@ DB_NAME_TASKS = "tasks"
 DB_NAME_SETTINGS = "settings"
 MAX_RETRIES = 120
 RETRY_DELAY = 5
+SQL_ECHO = os.getenv("SQL_ECHO", "false").lower() == "true"
 
 Base = declarative_base()
 
@@ -32,7 +33,7 @@ Base = declarative_base()
 def create_db_engine_with_retries(url: str, retries: int, delay: int):
     for attempt in range(retries):
         try:
-            engine = create_engine(url, echo=True)
+            engine = create_engine(url, echo=SQL_ECHO)
             with engine.connect():
                 pass
             return engine

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -157,6 +157,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "23.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -272,22 +284,32 @@ source = { virtual = "." }
 dependencies = [
     { name = "flask" },
     { name = "greenlet" },
+    { name = "gunicorn" },
     { name = "psycopg2-binary" },
-    { name = "pytest" },
     { name = "requests" },
-    { name = "ruff" },
     { name = "sqlalchemy" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "flask", specifier = ">=3.1.2,<4.0.0" },
     { name = "greenlet", specifier = ">=3.5.3,<4.0.0" },
+    { name = "gunicorn", specifier = ">=23.0.0,<24.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.12,<3.0.0" },
-    { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
     { name = "requests", specifier = ">=2.34.2,<3.0.0" },
-    { name = "ruff", specifier = ">=0.15.20,<1.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.51,<3.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.1.1,<10.0.0" },
+    { name = "ruff", specifier = ">=0.15.20,<1.0.0" },
 ]
 
 [[package]]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   ollama:
-    image: ollama/ollama
+    image: ollama/ollama:0.31.1
     container_name: procrastinationbuddy-ollama
     volumes:
       - ./.volumes/ollama:/root/.ollama
@@ -17,13 +17,13 @@ services:
     image: postgres:18
     container_name: procrastinationbuddy-db
     environment:
-      POSTGRES_USER: taskuser
-      POSTGRES_PASSWORD: taskpass
-      POSTGRES_DB: tasks
+      POSTGRES_USER: ${POSTGRES_USER:-taskuser}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-taskpass}
+      POSTGRES_DB: ${POSTGRES_DB:-tasks}
     volumes:
       - ./.volumes/db:/var/lib/postgresql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U taskuser -d tasks -h localhost -p 5432"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-taskuser} -d ${POSTGRES_DB:-tasks} -h localhost -p 5432"]
       interval: 5s
       timeout: 3s
       retries: 30
@@ -40,14 +40,20 @@ services:
       ollama:
         condition: service_healthy
     environment:
-      POSTGRES_USER: taskuser
-      POSTGRES_PASSWORD: taskpass
-      POSTGRES_DB: tasks
+      POSTGRES_USER: ${POSTGRES_USER:-taskuser}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-taskpass}
+      POSTGRES_DB: ${POSTGRES_DB:-tasks}
       POSTGRES_HOST: procrastinationbuddy-db
       POSTGRES_PORT: 5432
       OLLAMA_URL: http://procrastinationbuddy-ollama:11434
     ports:
       - "5001:5001"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:5001/tasks/count >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
 
   frontend:
     build:
@@ -56,8 +62,14 @@ services:
     container_name: procrastinationbuddy-frontend
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "8501:8501"
     environment:
       BACKEND_URL: http://procrastinationbuddy-backend:5001
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8501/_stcore/health >/dev/null 2>&1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 15s

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,10 +5,13 @@ COPY pyproject.toml pyproject.toml
 COPY uv.lock uv.lock
 
 RUN apk add --no-cache build-base
-RUN pip install --no-cache-dir uv==0.11.26 && uv sync
+RUN pip install --no-cache-dir uv==0.11.26 && uv sync --no-dev
 
 COPY src/ ./src/
 
 ENV BACKEND_URL=http://backend:5001
 
-ENTRYPOINT [ "uv", "run", "streamlit", "run", "src/app.py", " --server.headless", "true" ]
+RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
+USER app
+
+ENTRYPOINT [ "uv", "run", "--no-dev", "streamlit", "run", "src/app.py", "--server.headless", "true" ]

--- a/frontend/pyproject.toml
+++ b/frontend/pyproject.toml
@@ -4,14 +4,15 @@ version = "0.1.0"
 description = "ProcrastinationBuddy Frontend"
 requires-python = ">=3.13"
 dependencies = [
-    "pytest>=9.1.1",
     "pytz>=2026.2",
     "requests>=2.34.2",
-    "ruff>=0.15.20",
     "st-theme>=1.2.3",
     "streamlit>=1.58.0",
     "streamlit-javascript>=0.1.5",
 ]
+
+[dependency-groups]
+dev = ["pytest>=9.1.1", "ruff>=0.15.20"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/frontend/uv.lock
+++ b/frontend/uv.lock
@@ -490,24 +490,32 @@ name = "procrastinationbuddy-frontend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "pytest" },
     { name = "pytz" },
     { name = "requests" },
-    { name = "ruff" },
     { name = "st-theme" },
     { name = "streamlit" },
     { name = "streamlit-javascript" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
-    { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytz", specifier = ">=2026.2" },
     { name = "requests", specifier = ">=2.34.2" },
-    { name = "ruff", specifier = ">=0.15.20" },
     { name = "st-theme", specifier = ">=1.2.3" },
     { name = "streamlit", specifier = ">=1.58.0" },
     { name = "streamlit-javascript", specifier = ">=0.1.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.20" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes #180, #181, #183, #184, #186, #189, #190, #191.

- **#183** — backend and frontend containers now run as an unprivileged `app` user instead of root.
- **#184** — backend runs via gunicorn instead of Flask's dev server (`gunicorn --chdir src --bind 0.0.0.0:5001 app:app`).
- **#181** — fixed the frontend Dockerfile's stray leading space in `" --server.headless"` that silently broke the flag (confirmed via local testing that Streamlit's non-TTY auto-headless-detection was masking this - it wasn't actually breaking functionality, but the flag itself was dead).
- **#180** — `SQLAlchemy`'s `echo=True` is now gated behind a `SQL_ECHO` env var (default off) instead of unconditionally logging every SQL statement.
- **#186** — Postgres credentials in `compose.yaml` now come from `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` env vars with the current dev values as defaults (so `buddy.sh start` still works with zero config). Added `.env.example`, gitignored `.env`.
- **#189** — pinned `ollama/ollama` to `0.31.1` instead of `:latest`.
- **#191** — added healthchecks for backend (`/tasks/count`) and frontend (`/_stcore/health`); frontend now depends on backend's health rather than just `service_started`.
- **#190** — moved `pytest`/`ruff` into a `uv` dev-dependency-group in both backend and frontend `pyproject.toml`; Dockerfiles now build with `uv sync --no-dev` so production images don't ship test/lint tooling.

## Test plan
- [x] `docker compose up` — all 4 services reach `healthy`
- [x] Verified backend/frontend run as non-root (`whoami` → `app`)
- [x] Verified no SQL echo output in backend logs by default
- [x] Verified settings save/fetch works end-to-end through the running stack
- [x] `uv sync --no-dev` excludes pytest/ruff; plain `uv sync` (as used in CI) still includes them; `uv run ruff check .` + `uv run pytest` pass in both backend and frontend
- [x] Found and fixed a real issue during testing: Alpine's `/etc/hosts` resolves `localhost` to `::1` first, so `wget http://localhost:.../` in the healthcheck failed against gunicorn/streamlit's IPv4-only bind — switched healthchecks to `127.0.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)