### PR TITLE
Add CONTRIBUTING.md, SECURITY.md, and document env vars/API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for considering a contribution to Procrastination Buddy!
+
+## Getting set up
+
+You need **Docker** and **Docker Compose** (or **Docker Desktop**, which includes both) and a **bash** shell.
+
+```bash
+./buddy.sh start   # build images, start the stack, pull the default model
+./buddy.sh test    # run the API (Bruno) and E2E (Playwright) suites
+./buddy.sh stop    # stop everything
+```
+
+The app is then available at [http://localhost:8501](http://localhost:8501).
+
+## Project layout
+
+- `backend/` — Flask API (`src/`), unit tests (`test/`)
+- `frontend/` — Streamlit UI (`src/`), unit tests (`test/`)
+- `tests/api/` — Bruno API test collection
+- `tests/e2e/` — Playwright end-to-end tests
+- `compose.yaml` — local dev orchestration for all services
+
+## Running checks locally
+
+Backend and frontend each use [uv](https://docs.astral.sh/uv/) for dependency management:
+
+```bash
+cd backend  # or frontend
+uv sync
+uv run ruff check .
+uv run pytest
+```
+
+CI (`.github/workflows/quality-gate.yaml`) runs the same lint/tests, plus the full API/E2E suite against a running stack and a container vulnerability scan (Trivy) on both Docker images. Make sure these pass before opening a pull request.
+
+## Environment variables
+
+See the [Environment Variables](README.md#environment-variables) section in the README, and `.env.example` for local overrides.
+
+## Pull requests
+
+- Keep PRs focused; unrelated changes make review harder.
+- Update or add tests for behavior you change.
+- Describe what changed and why in the PR description.
+
+## Reporting bugs or security issues
+
+- Regular bugs: open a [GitHub issue](https://github.com/nobuddyorg/ProcrastinationBuddy/issues).
+- Security vulnerabilities: see [SECURITY.md](SECURITY.md) instead of opening a public issue.

--- a/README.md
+++ b/README.md
@@ -55,9 +55,44 @@ The app is built using Docker and Docker Compose to containerize and orchestrate
 - An **Ollama service** that runs an AI model responsible for generating the tasks.
 - A **PostgreSQL** Database for storing settings and tasks.
 
+## Environment Variables
+
+`buddy.sh start` / `docker compose up` work out of the box with sensible defaults. Copy [`.env.example`](.env.example) to `.env` to override any of these for your local setup:
+
+| Variable | Used by | Default | Description |
+| --- | --- | --- | --- |
+| `POSTGRES_USER` | db, backend | `taskuser` | Postgres username |
+| `POSTGRES_PASSWORD` | db, backend | `taskpass` | Postgres password |
+| `POSTGRES_DB` | db, backend | `tasks` | Postgres database name |
+
+These are set internally by `compose.yaml` and don't need overriding for local dev:
+
+| Variable | Used by | Description |
+| --- | --- | --- |
+| `POSTGRES_HOST` / `POSTGRES_PORT` | backend | Address of the `db` service |
+| `OLLAMA_URL` | backend | Address of the `ollama` service |
+| `BACKEND_URL` | frontend | Address of the `backend` service |
+| `SQL_ECHO` | backend | Set to `true` to log every SQL statement (default off) |
+
+## API Reference
+
+The backend exposes a small JSON API on port `5001`:
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/settings` | Fetch saved settings |
+| `POST` | `/settings` | Save settings (`LANGUAGE`, `TIMEZONE`, `MODEL`, `PAGE_SIZE`) |
+| `POST` | `/tasks` | Generate a new task (`language`, `model`) |
+| `GET` | `/tasks` | List tasks (`skip`, `limit`, `favorite`) |
+| `GET` | `/tasks/count` | Count tasks (`favorite`) |
+| `POST` | `/tasks/<id>/like` | Update a task's favorite status (`like`: 0 or 1) |
+| `DELETE` | `/tasks` | Delete tasks (`keep_favorites`) |
+
+See [`tests/api`](tests/api) for a runnable Bruno collection covering every endpoint.
+
 ## Contributing
 
-I welcome contributions! Feel free to fork the repository and open a pull request, whether it’s for new features, bug fixes, or UI improvements.
+I welcome contributions! Feel free to fork the repository and open a pull request, whether it’s for new features, bug fixes, or UI improvements. See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup and testing instructions.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+Instead, report it privately via [GitHub Security Advisories](https://github.com/nobuddyorg/ProcrastinationBuddy/security/advisories/new) for this repository. Include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof of concept if possible.
+- The affected version/commit.
+
+We'll acknowledge your report and work with you on a fix and disclosure timeline.
+
+## Supported versions
+
+This project does not maintain long-term release branches; only the latest code on `main` is supported. Dependency vulnerabilities are tracked via Dependabot and container image scanning (Trivy) in CI.


### PR DESCRIPTION
## Summary
Closes #192, #193.

- **#192** — added `CONTRIBUTING.md` (local setup, project layout, how to run lint/tests, PR expectations) and `SECURITY.md` (private vulnerability reporting via GitHub Security Advisories).
- **#193** — documented every environment variable the app reads (`POSTGRES_*`, `OLLAMA_URL`, `BACKEND_URL`, `SQL_ECHO`) in the README, plus a quick-reference table for the backend's HTTP API, linking to the existing Bruno collection for full request/response detail.

Note: the env var table documents `POSTGRES_USER/PASSWORD/DB` as overridable via `.env` and mentions `SQL_ECHO` — both land in #198 (Docker/infra hardening), which is in flight alongside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)