### PR TITLE
Extract shared HTTP request helper for frontend API clients

### DIFF
--- a/frontend/src/utils/http.py
+++ b/frontend/src/utils/http.py
@@ -1,0 +1,14 @@
+import requests
+from utils.text import handle_request_error
+
+
+def api_request(method: str, url: str, action: str, **kwargs):
+    """Perform an HTTP request, surfacing a UI error and returning None if it
+    fails; otherwise returns the successful `requests.Response`."""
+    try:
+        response = getattr(requests, method)(url, **kwargs)
+        response.raise_for_status()
+        return response
+    except requests.exceptions.RequestException as e:
+        handle_request_error(action, e)
+        return None

--- a/frontend/src/utils/settings_api.py
+++ b/frontend/src/utils/settings_api.py
@@ -1,28 +1,17 @@
-import requests
 import streamlit as st
 from config.constants import BACKEND_URL
-from utils.text import handle_request_error
+from utils.http import api_request
 
 
 def load_settings():
     """Fetch settings from the backend."""
-    try:
-        response = requests.get(f"{BACKEND_URL}/settings")
-        response.raise_for_status()
-        return response.json()
-    except requests.exceptions.RequestException as e:
-        handle_request_error("loading", e)
-        return None
+    response = api_request("get", f"{BACKEND_URL}/settings", "loading")
+    return response.json() if response is not None else None
 
 
 def save_settings():
     """Send updated settings to the backend."""
-    try:
-        response = requests.post(
-            f"{BACKEND_URL}/settings", json=st.session_state.settings
-        )
-        response.raise_for_status()
-        return True
-    except requests.exceptions.RequestException as e:
-        handle_request_error("saving", e)
-        return False
+    response = api_request(
+        "post", f"{BACKEND_URL}/settings", "saving", json=st.session_state.settings
+    )
+    return response is not None

--- a/frontend/src/utils/tasks_api.py
+++ b/frontend/src/utils/tasks_api.py
@@ -1,9 +1,8 @@
-import requests
 import streamlit as st
 from datetime import datetime
 from email.utils import parsedate_to_datetime
 from config.constants import BACKEND_URL
-from utils.text import handle_request_error
+from utils.http import api_request
 
 
 def _get_setting(key: str):
@@ -12,93 +11,87 @@ def _get_setting(key: str):
 
 def create_task():
     """Create a new task based on current language and model settings."""
-    try:
-        response = requests.post(
-            f"{BACKEND_URL}/tasks",
-            json={
-                "language": _get_setting("LANGUAGE"),
-                "model": _get_setting("MODEL"),
-            },
-        )
-        response.raise_for_status()
-        task_text = response.json()["task"].strip('"')
-
-        task_entry = {"text": task_text, "time": datetime.now().astimezone()}
-        st.session_state.setdefault("task_list", []).insert(0, task_entry)
-
-        page_size = _get_setting("PAGE_SIZE")
-        st.session_state.task_list = st.session_state.task_list[:page_size]
-        return task_text
-    except requests.exceptions.RequestException as e:
-        handle_request_error("generating task", e)
+    response = api_request(
+        "post",
+        f"{BACKEND_URL}/tasks",
+        "generating task",
+        json={
+            "language": _get_setting("LANGUAGE"),
+            "model": _get_setting("MODEL"),
+        },
+    )
+    if response is None:
         return "Failed to get a task."
+
+    task_text = response.json()["task"].strip('"')
+
+    task_entry = {"text": task_text, "time": datetime.now().astimezone()}
+    st.session_state.setdefault("task_list", []).insert(0, task_entry)
+
+    page_size = _get_setting("PAGE_SIZE")
+    st.session_state.task_list = st.session_state.task_list[:page_size]
+    return task_text
 
 
 def fetch_tasks():
     """Fetch a paginated list of tasks with optional filtering by favorite."""
-    try:
-        page = st.session_state.page_number
-        page_size = _get_setting("PAGE_SIZE")
-        params = {
-            "skip": (page - 1) * page_size,
-            "limit": page_size,
-        }
-        if st.session_state.feedback_filter:
-            params["favorite"] = 1
+    page = st.session_state.page_number
+    page_size = _get_setting("PAGE_SIZE")
+    params = {
+        "skip": (page - 1) * page_size,
+        "limit": page_size,
+    }
+    if st.session_state.feedback_filter:
+        params["favorite"] = 1
 
-        response = requests.get(f"{BACKEND_URL}/tasks", params=params)
-        response.raise_for_status()
+    response = api_request(
+        "get", f"{BACKEND_URL}/tasks", "fetching tasks", params=params
+    )
+    if response is None:
+        return
 
-        task_data = response.json()
-        st.session_state.task_list = sorted(
-            [
-                {
-                    "id": task["id"],
-                    "text": task["task_text"],
-                    "time": parsedate_to_datetime(task["created_at"]),
-                    "favorite": task.get("favorite", False),
-                }
-                for task in task_data
-            ],
-            key=lambda t: t["time"],
-            reverse=True,
-        )
-    except requests.exceptions.RequestException as e:
-        handle_request_error("fetching tasks", e)
+    task_data = response.json()
+    st.session_state.task_list = sorted(
+        [
+            {
+                "id": task["id"],
+                "text": task["task_text"],
+                "time": parsedate_to_datetime(task["created_at"]),
+                "favorite": task.get("favorite", False),
+            }
+            for task in task_data
+        ],
+        key=lambda t: t["time"],
+        reverse=True,
+    )
 
 
 def set_task_as_favorite(task, like=0):
     """Update the favorite status of a task."""
-    try:
-        if task.get("favorite", 0) != like:
-            response = requests.post(
-                f"{BACKEND_URL}/tasks/{task['id']}/like",
-                json={"like": like},
-            )
-            response.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        handle_request_error("updating favorite status", e)
+    if task.get("favorite", 0) != like:
+        api_request(
+            "post",
+            f"{BACKEND_URL}/tasks/{task['id']}/like",
+            "updating favorite status",
+            json={"like": like},
+        )
 
 
 def get_task_count(favorite=False):
     """Return the count of tasks, optionally filtered by favorite status."""
-    try:
-        params = {"favorite": 1} if favorite else {}
-        response = requests.get(f"{BACKEND_URL}/tasks/count", params=params)
-        response.raise_for_status()
-        return response.json().get("count", 0)
-    except requests.exceptions.RequestException as e:
-        handle_request_error("fetching task count", e)
-        return 0
+    params = {"favorite": 1} if favorite else {}
+    response = api_request(
+        "get", f"{BACKEND_URL}/tasks/count", "fetching task count", params=params
+    )
+    return response.json().get("count", 0) if response is not None else 0
 
 
 def delete_tasks():
     """Delete all tasks, optionally preserving favorites."""
-    try:
-        keep_favorites = 1 if st.session_state.keep_favorites else 0
-        response = requests.delete(
-            f"{BACKEND_URL}/tasks", params={"keep_favorites": keep_favorites}
-        )
-        response.raise_for_status()
-    except requests.exceptions.RequestException as e:
-        handle_request_error("deleting tasks", e)
+    keep_favorites = 1 if st.session_state.keep_favorites else 0
+    api_request(
+        "delete",
+        f"{BACKEND_URL}/tasks",
+        "deleting tasks",
+        params={"keep_favorites": keep_favorites},
+    )

--- a/frontend/test/test_http.py
+++ b/frontend/test/test_http.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch, MagicMock
+import requests
+
+from utils.http import api_request
+
+
+@patch("utils.http.requests.get")
+def test_api_request_returns_response_on_success(mock_get):
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    result = api_request("get", "http://example.test/thing", "doing a thing")
+
+    assert result is mock_response
+    mock_get.assert_called_once_with("http://example.test/thing")
+
+
+@patch("utils.http.handle_request_error")
+@patch(
+    "utils.http.requests.post",
+    side_effect=requests.exceptions.RequestException("boom"),
+)
+def test_api_request_returns_none_and_surfaces_error_on_failure(
+    mock_post, mock_error_handler
+):
+    result = api_request("post", "http://example.test/thing", "doing a thing")
+
+    assert result is None
+    mock_error_handler.assert_called_once()
+    assert mock_error_handler.call_args[0][0] == "doing a thing"
+
+
+@patch("utils.http.requests.get")
+def test_api_request_returns_none_on_http_error_status(mock_get):
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "500 Server Error"
+    )
+    mock_get.return_value = mock_response
+
+    with patch("utils.http.handle_request_error") as mock_error_handler:
+        result = api_request("get", "http://example.test/thing", "doing a thing")
+
+    assert result is None
+    mock_error_handler.assert_called_once()

--- a/frontend/test/test_settings_api.py
+++ b/frontend/test/test_settings_api.py
@@ -4,9 +4,9 @@ import requests
 from utils.settings_api import load_settings, save_settings
 
 
-@patch("utils.settings_api.handle_request_error")
+@patch("utils.http.handle_request_error")
 @patch(
-    "utils.settings_api.requests.get",
+    "utils.http.requests.get",
     side_effect=requests.exceptions.RequestException("Network error"),
 )
 def test_load_settings_failure(mock_get, mock_error_handler):
@@ -17,7 +17,7 @@ def test_load_settings_failure(mock_get, mock_error_handler):
 
 
 @patch("utils.settings_api.BACKEND_URL", "http://localhost:8000")
-@patch("utils.settings_api.requests.post")
+@patch("utils.http.requests.post")
 @patch("utils.settings_api.st")
 def test_save_settings_success(mock_st, mock_post):
     mock_st.session_state.settings = {"theme": "light"}
@@ -33,10 +33,10 @@ def test_save_settings_success(mock_st, mock_post):
     )
 
 
-@patch("utils.settings_api.handle_request_error")
+@patch("utils.http.handle_request_error")
 @patch("utils.settings_api.st")
 @patch(
-    "utils.settings_api.requests.post",
+    "utils.http.requests.post",
     side_effect=requests.exceptions.RequestException("Server error"),
 )
 def test_save_settings_failure(mock_post, mock_st, mock_error_handler):

--- a/frontend/test/test_task_api.py
+++ b/frontend/test/test_task_api.py
@@ -17,7 +17,7 @@ mock_settings = {
 
 
 @patch("utils.tasks_api._get_setting", side_effect=lambda k: mock_settings[k])
-@patch("utils.tasks_api.requests.post")
+@patch("utils.http.requests.post")
 @patch("utils.tasks_api.st")
 def test_create_task_success(mock_st, mock_post, mock_get_setting):
     mock_response = MagicMock()
@@ -32,7 +32,7 @@ def test_create_task_success(mock_st, mock_post, mock_get_setting):
 
 
 @patch("utils.tasks_api._get_setting", side_effect=lambda k: mock_settings[k])
-@patch("utils.tasks_api.requests.get")
+@patch("utils.http.requests.get")
 @patch("utils.tasks_api.st")
 def test_fetch_tasks_success(mock_st, mock_get, mock_get_setting):
     mock_st.session_state.page_number = 1
@@ -61,7 +61,7 @@ def test_fetch_tasks_success(mock_st, mock_get, mock_get_setting):
     assert mock_get.called
 
 
-@patch("utils.tasks_api.requests.post")
+@patch("utils.http.requests.post")
 @patch("utils.tasks_api.st")
 def test_set_task_as_favorite_changes_status(mock_st, mock_post):
     task = {"id": 123, "favorite": False}
@@ -74,7 +74,7 @@ def test_set_task_as_favorite_changes_status(mock_st, mock_post):
     mock_post.assert_called_once_with(f"{BACKEND_URL}/tasks/123/like", json={"like": 1})
 
 
-@patch("utils.tasks_api.requests.post")
+@patch("utils.http.requests.post")
 @patch("utils.tasks_api.st")
 def test_set_task_as_favorite_no_change(mock_st, mock_post):
     task = {"id": 123, "favorite": 1}
@@ -82,7 +82,7 @@ def test_set_task_as_favorite_no_change(mock_st, mock_post):
     mock_post.assert_not_called()
 
 
-@patch("utils.tasks_api.requests.get")
+@patch("utils.http.requests.get")
 @patch("utils.tasks_api.st")
 def test_get_task_count(mock_st, mock_get):
     mock_get.return_value = MagicMock(
@@ -94,7 +94,7 @@ def test_get_task_count(mock_st, mock_get):
     mock_get.assert_called_once_with(f"{BACKEND_URL}/tasks/count", params={})
 
 
-@patch("utils.tasks_api.requests.get")
+@patch("utils.http.requests.get")
 @patch("utils.tasks_api.st")
 def test_get_task_count_favorites(mock_st, mock_get):
     mock_get.return_value = MagicMock(
@@ -108,7 +108,7 @@ def test_get_task_count_favorites(mock_st, mock_get):
     )
 
 
-@patch("utils.tasks_api.requests.delete")
+@patch("utils.http.requests.delete")
 @patch("utils.tasks_api.st")
 def test_delete_tasks(mock_st, mock_delete):
     mock_st.session_state.keep_favorites = True


### PR DESCRIPTION
## Summary
Closes #195.

`tasks_api.py` and `settings_api.py` each duplicated the same try/`requests.<method>`/`raise_for_status`/except-`RequestException` boilerplate per function. Extracted a single `api_request(method, url, action, **kwargs)` helper in the new `utils/http.py` that performs the request, surfaces failures via the existing `handle_request_error`, and returns `None` on failure (or the `Response` on success) — callers extract whatever they need from the response themselves, preserving each call site's existing fallback behavior exactly.

Updated existing tests' patch targets from `utils.tasks_api.requests`/`utils.settings_api.requests` to `utils.http.requests`, since that's where requests calls are now issued from (necessary collateral of the refactor, not a behavior change). Added `test_http.py` for the helper itself.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run pytest` — 20/20 passing (17 existing + 3 new for the helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)