### PR TITLE
Add type hints to backend public functions

### DIFF
--- a/backend/src/db/db.py
+++ b/backend/src/db/db.py
@@ -1,5 +1,6 @@
 import os
 import time
+from collections.abc import Callable, Generator
 from datetime import datetime, timezone
 
 from sqlalchemy import (
@@ -10,8 +11,10 @@ from sqlalchemy import (
     DateTime,
     JSON,
 )
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session
 from sqlalchemy.exc import OperationalError
 
 # -----------------------#
@@ -30,7 +33,7 @@ Base = declarative_base()
 # -----------------------#
 # Database Engine Setup
 # -----------------------#
-def create_db_engine_with_retries(url: str, retries: int, delay: int):
+def create_db_engine_with_retries(url: str, retries: int, delay: int) -> Engine:
     for attempt in range(retries):
         try:
             engine = create_engine(url, echo=SQL_ECHO)
@@ -46,7 +49,7 @@ def create_db_engine_with_retries(url: str, retries: int, delay: int):
 # -----------------------#
 # Utility
 # -----------------------#
-def utc_now():
+def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
@@ -77,7 +80,7 @@ _engine = None
 _Session = None
 
 
-def init_db():
+def init_db() -> None:
     global _engine, _Session
     if _engine is None:
         _engine = create_db_engine_with_retries(DATABASE_URL, MAX_RETRIES, RETRY_DELAY)
@@ -85,7 +88,7 @@ def init_db():
         Base.metadata.create_all(bind=_engine)
 
 
-def get_db():
+def get_db() -> Generator[Session, None, None]:
     if _Session is None:
         init_db()
     db = _Session()
@@ -95,7 +98,7 @@ def get_db():
         db.close()
 
 
-def with_db_session(func):
+def with_db_session(func: Callable) -> Callable:
     def wrapper(*args, **kwargs):
         db_gen = get_db()
         db = next(db_gen)
@@ -113,7 +116,7 @@ def with_db_session(func):
 # -----------------------#
 # CRUD Operations
 # -----------------------#
-def add_task_to_db(db, task_text: str):
+def add_task_to_db(db: Session, task_text: str) -> None:
     """Add a new task and keep only the latest 500 tasks in the DB."""
     new_task = Task(task_text=task_text)
     db.add(new_task)
@@ -127,7 +130,7 @@ def add_task_to_db(db, task_text: str):
     db.commit()
 
 
-def like_task_in_db(db, task_id: int, like: int):
+def like_task_in_db(db: Session, task_id: int, like: int) -> Task | None:
     """Like or unlike a task."""
     task = db.query(Task).filter(Task.id == task_id).first()
     if task:
@@ -137,21 +140,23 @@ def like_task_in_db(db, task_id: int, like: int):
     return task
 
 
-def get_tasks_from_db(db, skip: int = 0, limit: int = 10, favorite: bool = None):
+def get_tasks_from_db(
+    db: Session, skip: int = 0, limit: int = 10, favorite: bool | None = None
+) -> list[Task]:
     query = db.query(Task).order_by(Task.created_at.desc())
     if favorite is not None:
         query = query.filter(Task.favorite == int(favorite))
     return query.offset(skip).limit(limit).all()
 
 
-def count_tasks_in_db(db, favorite: bool = None):
+def count_tasks_in_db(db: Session, favorite: bool | None = None) -> int:
     query = db.query(Task)
     if favorite is not None:
         query = query.filter(Task.favorite == int(favorite))
     return query.count()
 
 
-def delete_tasks_in_db(db, keep_favorites: bool = True):
+def delete_tasks_in_db(db: Session, keep_favorites: bool = True) -> int:
     query = db.query(Task)
     if keep_favorites:
         query = query.filter(Task.favorite == 0)
@@ -160,11 +165,11 @@ def delete_tasks_in_db(db, keep_favorites: bool = True):
     return deleted_count
 
 
-def get_app_settings_from_db(db):
+def get_app_settings_from_db(db: Session) -> AppSettings | None:
     return db.query(AppSettings).first()
 
 
-def save_app_settings_to_db(db, settings: dict):
+def save_app_settings_to_db(db: Session, settings: dict) -> AppSettings:
     record = db.query(AppSettings).first()
     if record:
         record.settings = settings

--- a/backend/src/routes/settings.py
+++ b/backend/src/routes/settings.py
@@ -1,5 +1,6 @@
 import logging
 from flask import Blueprint, request, jsonify
+from flask.typing import ResponseReturnValue
 from services.settings import get_settings, save_settings
 
 settings_bp = Blueprint("settings", __name__)
@@ -13,7 +14,7 @@ REQUIRED_SETTINGS = {
 }
 
 
-def _validate_settings(payload):
+def _validate_settings(payload: object) -> str | None:
     if not isinstance(payload, dict):
         return "Settings payload must be a JSON object."
     for key, expected_type in REQUIRED_SETTINGS.items():
@@ -29,7 +30,7 @@ def _validate_settings(payload):
 
 
 @settings_bp.route("/settings", methods=["GET", "POST"])
-def handle_settings():
+def handle_settings() -> ResponseReturnValue:
     if request.method == "GET":
         try:
             record = get_settings()

--- a/backend/src/routes/tasks.py
+++ b/backend/src/routes/tasks.py
@@ -3,6 +3,7 @@ import re
 import logging
 import threading
 from flask import Blueprint, request, jsonify
+from flask.typing import ResponseReturnValue
 from services.tasks import (
     generate_task,
     list_tasks,
@@ -21,7 +22,7 @@ MODEL_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._:/-]{0,127})?$")
 
 
 @tasks_bp.route("/tasks", methods=["POST"])
-def create_task():
+def create_task() -> ResponseReturnValue:
     data = request.get_json(silent=True) or {}
     language = data.get("language", "english")
     model = data.get("model", "mistral:instruct")
@@ -39,7 +40,7 @@ def create_task():
 
 
 @tasks_bp.route("/tasks", methods=["GET"])
-def get_tasks():
+def get_tasks() -> ResponseReturnValue:
     try:
         skip = request.args.get("skip", 0, type=int)
         limit = request.args.get("limit", 10, type=int)
@@ -53,7 +54,7 @@ def get_tasks():
 
 
 @tasks_bp.route("/tasks/count", methods=["GET"])
-def get_task_count():
+def get_task_count() -> ResponseReturnValue:
     try:
         favorite = request.args.get("favorite", type=int)
         count = count_tasks(favorite=favorite)
@@ -64,7 +65,7 @@ def get_task_count():
 
 
 @tasks_bp.route("/tasks/<int:task_id>/like", methods=["POST"])
-def update_like(task_id):
+def update_like(task_id: int) -> ResponseReturnValue:
     data = request.get_json(silent=True) or {}
     like = data.get("like")
 
@@ -80,7 +81,7 @@ def update_like(task_id):
 
 
 @tasks_bp.route("/tasks", methods=["DELETE"])
-def delete_tasks():
+def delete_tasks() -> ResponseReturnValue:
     try:
         keep_favorites = request.args.get("keep_favorites", default=1, type=int)
         delete_all_tasks(keep_favorites=bool(keep_favorites))

--- a/backend/src/services/settings.py
+++ b/backend/src/services/settings.py
@@ -1,11 +1,13 @@
+from sqlalchemy.orm import Session
 from db.db import with_db_session, get_app_settings_from_db, save_app_settings_to_db
+from db.db import AppSettings
 
 
 @with_db_session
-def get_settings(db):
+def get_settings(db: Session) -> AppSettings | None:
     return get_app_settings_from_db(db)
 
 
 @with_db_session
-def save_settings(db, settings):
+def save_settings(db: Session, settings: dict) -> AppSettings:
     return save_app_settings_to_db(db, settings)

--- a/backend/src/services/tasks.py
+++ b/backend/src/services/tasks.py
@@ -1,4 +1,5 @@
 import requests
+from sqlalchemy.orm import Session
 from db.db import (
     with_db_session,
     add_task_to_db,
@@ -9,7 +10,7 @@ from db.db import (
 )
 
 
-def ensure_model_exists(url, model):
+def ensure_model_exists(url: str, model: str) -> None:
     tags_response = requests.get(f"{url}/api/tags")
     tags_response.raise_for_status()
     models = [m["name"] for m in tags_response.json().get("models", [])]
@@ -19,7 +20,7 @@ def ensure_model_exists(url, model):
 
 
 @with_db_session
-def generate_task(db, url, language, model):
+def generate_task(db: Session, url: str, language: str, model: str) -> str:
     ensure_model_exists(url, model)
     response = requests.post(
         f"{url}/api/generate",
@@ -36,7 +37,7 @@ def generate_task(db, url, language, model):
     return task_text
 
 
-def generate_prompt(language):
+def generate_prompt(language: str) -> str:
     examples = [
         "watch baby animal videos on Youtube",
         "Count the number of tiles in the bathroom",
@@ -59,12 +60,14 @@ Respond only with the task itself.
 
 
 @with_db_session
-def like_task(db, task_id, like):
+def like_task(db: Session, task_id: int, like: int) -> None:
     like_task_in_db(db, task_id, like)
 
 
 @with_db_session
-def list_tasks(db, skip=0, limit=10, favorite=None):
+def list_tasks(
+    db: Session, skip: int = 0, limit: int = 10, favorite: bool | None = None
+) -> list[dict]:
     tasks = get_tasks_from_db(
         db,
         skip=skip,
@@ -83,10 +86,10 @@ def list_tasks(db, skip=0, limit=10, favorite=None):
 
 
 @with_db_session
-def count_tasks(db, favorite=None):
+def count_tasks(db: Session, favorite: bool | None = None) -> int:
     return count_tasks_in_db(db, favorite=favorite)
 
 
 @with_db_session
-def delete_all_tasks(db, keep_favorites=True):
+def delete_all_tasks(db: Session, keep_favorites: bool = True) -> None:
     delete_tasks_in_db(db, keep_favorites=keep_favorites)


### PR DESCRIPTION
## Summary
Closes #194.

Scoped to `backend/src` (routes, services, `db.py`) as agreed — frontend Streamlit UI code is intentionally out of scope: `st.session_state`'s dynamic dict-like access and Streamlit's loosely-typed widget API make hints low-value there without a much bigger investment (TypedDicts, stubs), which isn't proportionate for a low-priority style item.

- `db/db.py`: `Session`/`Engine`/`Task`/`AppSettings` types on all CRUD and engine-setup functions.
- `services/tasks.py`, `services/settings.py`: matching types on the `@with_db_session`-wrapped functions.
- `routes/tasks.py`, `routes/settings.py`: `flask.typing.ResponseReturnValue` on route handlers.

## Test plan
- [x] `uv run ruff check .` clean
- [x] `uv run pytest` — 25/25 passing, no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)