### PR TITLE
Block generation until model is downloaded, with visible progress

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,4 +12,4 @@ COPY src/ ./src/
 RUN addgroup -S app && adduser -S app -G app && chown -R app:app /app
 USER app
 
-ENTRYPOINT [ "uv", "run", "--no-dev", "gunicorn", "--chdir", "src", "--bind", "0.0.0.0:5001", "app:app" ]
+ENTRYPOINT [ "uv", "run", "--no-dev", "gunicorn", "--chdir", "src", "--bind", "0.0.0.0:5001", "--timeout", "300", "app:app" ]

--- a/backend/src/routes/tasks.py
+++ b/backend/src/routes/tasks.py
@@ -10,6 +10,8 @@ from services.tasks import (
     count_tasks,
     like_task,
     delete_all_tasks,
+    get_model_status,
+    ensure_model_pulling,
 )
 
 tasks_bp = Blueprint("tasks", __name__)
@@ -31,12 +33,45 @@ def create_task() -> ResponseReturnValue:
         return jsonify({"error": "Invalid 'model' value."}), 400
 
     try:
+        status = get_model_status(OLLAMA_URL, model)
+        if status["status"] != "ready":
+            ensure_model_pulling(OLLAMA_URL, model)
+            return jsonify({"error": "Model is not ready yet.", **status}), 409
+
         with ollama_lock:
             task = generate_task(OLLAMA_URL, language, model)
         return jsonify({"task": task}), 201
     except Exception:
         logger.exception("Task generation failed")
         return jsonify({"error": "Task generation failed."}), 500
+
+
+@tasks_bp.route("/models/status", methods=["GET"])
+def model_status() -> ResponseReturnValue:
+    model = request.args.get("model", "")
+    if not model or not MODEL_NAME_RE.match(model):
+        return jsonify({"error": "Invalid 'model' value."}), 400
+
+    try:
+        return jsonify(get_model_status(OLLAMA_URL, model)), 200
+    except Exception:
+        logger.exception("Failed to get model status")
+        return jsonify({"error": "Failed to get model status."}), 500
+
+
+@tasks_bp.route("/models/pull", methods=["POST"])
+def pull_model() -> ResponseReturnValue:
+    data = request.get_json(silent=True) or {}
+    model = data.get("model", "")
+    if not isinstance(model, str) or not model or not MODEL_NAME_RE.match(model):
+        return jsonify({"error": "Invalid 'model' value."}), 400
+
+    try:
+        ensure_model_pulling(OLLAMA_URL, model)
+        return jsonify(get_model_status(OLLAMA_URL, model)), 202
+    except Exception:
+        logger.exception("Failed to start model download")
+        return jsonify({"error": "Failed to start model download."}), 500
 
 
 @tasks_bp.route("/tasks", methods=["GET"])

--- a/backend/src/services/tasks.py
+++ b/backend/src/services/tasks.py
@@ -1,3 +1,5 @@
+import json
+import threading
 import requests
 from sqlalchemy.orm import Session
 from db.db import (
@@ -9,19 +11,90 @@ from db.db import (
     delete_tasks_in_db,
 )
 
+_pull_state: dict[str, dict] = {}
+_pull_state_lock = threading.Lock()
 
-def ensure_model_exists(url: str, model: str) -> None:
+
+def _set_pull_state(model: str, **fields) -> None:
+    with _pull_state_lock:
+        _pull_state.setdefault(model, {}).update(fields)
+
+
+def _get_pull_state(model: str) -> dict:
+    with _pull_state_lock:
+        return dict(_pull_state.get(model, {}))
+
+
+def model_available(url: str, model: str) -> bool:
+    """Check with Ollama whether `model` has already been pulled."""
     tags_response = requests.get(f"{url}/api/tags")
     tags_response.raise_for_status()
     models = [m["name"] for m in tags_response.json().get("models", [])]
-    if model not in models:
-        pull_response = requests.post(f"{url}/api/pull", json={"name": model})
-        pull_response.raise_for_status()
+    return model in models
+
+
+def get_model_status(url: str, model: str) -> dict:
+    """Return the current readiness of `model`: ready, downloading, error or not_downloaded."""
+    state = _get_pull_state(model)
+    status = state.get("status")
+
+    if status == "downloading":
+        return {
+            "status": "downloading",
+            "detail": state.get("detail", ""),
+            "completed": state.get("completed", 0),
+            "total": state.get("total", 0),
+        }
+    if status == "error":
+        return {"status": "error", "error": state.get("error", "")}
+    if status == "ready":
+        return {"status": "ready"}
+
+    if model_available(url, model):
+        _set_pull_state(model, status="ready")
+        return {"status": "ready"}
+    return {"status": "not_downloaded"}
+
+
+def ensure_model_pulling(url: str, model: str) -> None:
+    """Kick off a background download of `model` if it isn't ready or already downloading."""
+    if _get_pull_state(model).get("status") == "downloading":
+        return
+    if model_available(url, model):
+        _set_pull_state(model, status="ready")
+        return
+
+    thread = threading.Thread(target=_run_pull, args=(url, model), daemon=True)
+    thread.start()
+
+
+def _run_pull(url: str, model: str) -> None:
+    try:
+        _set_pull_state(model, status="downloading", detail="starting", completed=0, total=0)
+        with requests.post(
+            f"{url}/api/pull", json={"name": model, "stream": True}, stream=True
+        ) as pull_response:
+            pull_response.raise_for_status()
+            for line in pull_response.iter_lines():
+                if not line:
+                    continue
+                data = json.loads(line)
+                fields = {"status": "downloading", "detail": data.get("status", "")}
+                # Trailing messages (e.g. "verifying sha256 digest") omit
+                # completed/total; keep the last known progress instead of
+                # resetting the bar to 0.
+                if "completed" in data:
+                    fields["completed"] = data["completed"]
+                if "total" in data:
+                    fields["total"] = data["total"]
+                _set_pull_state(model, **fields)
+        _set_pull_state(model, status="ready")
+    except Exception as e:
+        _set_pull_state(model, status="error", error=str(e))
 
 
 @with_db_session
 def generate_task(db: Session, url: str, language: str, model: str) -> str:
-    ensure_model_exists(url, model)
     response = requests.post(
         f"{url}/api/generate",
         json={

--- a/backend/test/test_tasks_route.py
+++ b/backend/test/test_tasks_route.py
@@ -17,7 +17,9 @@ def client(app):
 
 
 def test_create_task_success(client):
-    with patch("routes.tasks.generate_task", return_value="mock task") as mock_gen:
+    with patch(
+        "routes.tasks.get_model_status", return_value={"status": "ready"}
+    ), patch("routes.tasks.generate_task", return_value="mock task") as mock_gen:
         response = client.post(
             "/tasks", json={"language": "german", "model": "fake-model"}
         )
@@ -34,11 +36,60 @@ def test_create_task_invalid_model(client):
         mock_gen.assert_not_called()
 
 
+def test_create_task_model_not_ready(client):
+    with patch(
+        "routes.tasks.get_model_status",
+        return_value={"status": "downloading", "completed": 1, "total": 10},
+    ), patch("routes.tasks.ensure_model_pulling") as mock_pull, patch(
+        "routes.tasks.generate_task"
+    ) as mock_gen:
+        response = client.post("/tasks", json={"model": "fake-model"})
+        assert response.status_code == 409
+        body = response.get_json()
+        assert body["status"] == "downloading"
+        mock_pull.assert_called_once()
+        mock_gen.assert_not_called()
+
+
 def test_create_task_failure(client):
-    with patch("routes.tasks.generate_task", side_effect=Exception("fail")):
+    with patch(
+        "routes.tasks.get_model_status", return_value={"status": "ready"}
+    ), patch("routes.tasks.generate_task", side_effect=Exception("fail")):
         response = client.post("/tasks")
         assert response.status_code == 500
         assert "error" in response.get_json()
+
+
+def test_model_status_endpoint(client):
+    with patch(
+        "routes.tasks.get_model_status", return_value={"status": "ready"}
+    ) as mock_status:
+        response = client.get("/models/status?model=fake-model")
+        assert response.status_code == 200
+        assert response.get_json() == {"status": "ready"}
+        mock_status.assert_called_once()
+
+
+def test_model_status_endpoint_invalid_model(client):
+    response = client.get("/models/status?model=not a model!")
+    assert response.status_code == 400
+
+
+def test_pull_model_endpoint(client):
+    with patch("routes.tasks.ensure_model_pulling") as mock_pull, patch(
+        "routes.tasks.get_model_status", return_value={"status": "downloading"}
+    ):
+        response = client.post("/models/pull", json={"model": "fake-model"})
+        assert response.status_code == 202
+        assert response.get_json() == {"status": "downloading"}
+        mock_pull.assert_called_once()
+
+
+def test_pull_model_endpoint_invalid_model(client):
+    with patch("routes.tasks.ensure_model_pulling") as mock_pull:
+        response = client.post("/models/pull", json={"model": "not a model!"})
+        assert response.status_code == 400
+        mock_pull.assert_not_called()
 
 
 def test_get_tasks(client):

--- a/backend/test/test_tasks_service.py
+++ b/backend/test/test_tasks_service.py
@@ -1,4 +1,23 @@
-from services.tasks import generate_prompt
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+import services.tasks as tasks_module
+from services.tasks import (
+    generate_prompt,
+    model_available,
+    get_model_status,
+    ensure_model_pulling,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_pull_state():
+    """_pull_state is memoized at module level; reset between tests."""
+    original = tasks_module._pull_state
+    tasks_module._pull_state = {}
+    yield
+    tasks_module._pull_state = original
 
 
 def test_generate_prompt_contains_language_and_examples():
@@ -9,3 +28,127 @@ def test_generate_prompt_contains_language_and_examples():
     assert "Examples of my favorites" in prompt
     assert "You are 'Procrastination Buddy'" in prompt
     assert prompt.count("\n") > 5
+
+
+def test_model_available_true():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"models": [{"name": "smollm2:1.7b"}]}
+    with patch("services.tasks.requests.get", return_value=mock_response):
+        assert model_available("http://ollama", "smollm2:1.7b") is True
+
+
+def test_model_available_false():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"models": [{"name": "other-model"}]}
+    with patch("services.tasks.requests.get", return_value=mock_response):
+        assert model_available("http://ollama", "smollm2:1.7b") is False
+
+
+def test_get_model_status_ready_when_available():
+    with patch("services.tasks.model_available", return_value=True):
+        status = get_model_status("http://ollama", "smollm2:1.7b")
+    assert status == {"status": "ready"}
+
+
+def test_get_model_status_not_downloaded():
+    with patch("services.tasks.model_available", return_value=False):
+        status = get_model_status("http://ollama", "new-model")
+    assert status == {"status": "not_downloaded"}
+
+
+def test_get_model_status_reports_progress_while_downloading():
+    tasks_module._set_pull_state(
+        "new-model", status="downloading", detail="pulling", completed=5, total=10
+    )
+    status = get_model_status("http://ollama", "new-model")
+    assert status == {
+        "status": "downloading",
+        "detail": "pulling",
+        "completed": 5,
+        "total": 10,
+    }
+
+
+def test_get_model_status_reports_error():
+    tasks_module._set_pull_state("new-model", status="error", error="boom")
+    status = get_model_status("http://ollama", "new-model")
+    assert status == {"status": "error", "error": "boom"}
+
+
+def test_ensure_model_pulling_skips_if_already_downloading():
+    tasks_module._set_pull_state("new-model", status="downloading")
+    with patch("services.tasks.threading.Thread") as mock_thread:
+        ensure_model_pulling("http://ollama", "new-model")
+    mock_thread.assert_not_called()
+
+
+def test_ensure_model_pulling_skips_if_already_available():
+    with patch("services.tasks.model_available", return_value=True), patch(
+        "services.tasks.threading.Thread"
+    ) as mock_thread:
+        ensure_model_pulling("http://ollama", "new-model")
+    mock_thread.assert_not_called()
+    assert tasks_module._get_pull_state("new-model")["status"] == "ready"
+
+
+def test_ensure_model_pulling_starts_background_thread():
+    with patch("services.tasks.model_available", return_value=False), patch(
+        "services.tasks.threading.Thread"
+    ) as mock_thread:
+        ensure_model_pulling("http://ollama", "new-model")
+    mock_thread.assert_called_once()
+    mock_thread.return_value.start.assert_called_once()
+
+
+def test_run_pull_updates_progress_and_marks_ready():
+    lines = [
+        json.dumps({"status": "pulling manifest"}).encode(),
+        json.dumps({"status": "pulling digest", "completed": 5, "total": 10}).encode(),
+    ]
+    mock_response = MagicMock()
+    mock_response.iter_lines.return_value = lines
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+
+    with patch("services.tasks.requests.post", return_value=mock_response):
+        tasks_module._run_pull("http://ollama", "new-model")
+
+    assert tasks_module._get_pull_state("new-model") == {
+        "status": "ready",
+        "detail": "pulling digest",
+        "completed": 5,
+        "total": 10,
+    }
+
+
+def test_run_pull_preserves_progress_on_trailing_messages_without_totals():
+    """Ollama's final status lines (verifying/writing manifest) omit
+    completed/total; the progress bar must not reset to 0 because of them."""
+    lines = [
+        json.dumps({"status": "pulling digest", "completed": 10, "total": 10}).encode(),
+        json.dumps({"status": "verifying sha256 digest"}).encode(),
+        json.dumps({"status": "writing manifest"}).encode(),
+    ]
+    mock_response = MagicMock()
+    mock_response.iter_lines.return_value = lines
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = False
+
+    with patch("services.tasks.requests.post", return_value=mock_response):
+        tasks_module._run_pull("http://ollama", "new-model")
+
+    assert tasks_module._get_pull_state("new-model") == {
+        "status": "ready",
+        "detail": "writing manifest",
+        "completed": 10,
+        "total": 10,
+    }
+
+
+def test_run_pull_marks_error_on_failure():
+    with patch("services.tasks.requests.post", side_effect=Exception("network down")):
+        tasks_module._run_pull("http://ollama", "new-model")
+
+    state = tasks_module._get_pull_state("new-model")
+    assert state["status"] == "error"
+    assert "network down" in state["error"]

--- a/frontend/src/app.py
+++ b/frontend/src/app.py
@@ -4,21 +4,25 @@ from ui.rendering import (
     render_tasks,
     render_loading_spinner,
     render_pagination,
+    render_model_download_progress,
 )
 from ui.page_setup import setup_page, setup_custom_styles
 from config.state import configure_states
 from utils.tasks_api import fetch_tasks
+from utils.models_api import sync_model_status
 
 
 def main():
     configure_states()
     setup_page()
     setup_custom_styles()
+    sync_model_status()
     render_header_elements()
     fetch_tasks()
     render_tasks(st.container())
     render_pagination()
     render_loading_spinner()
+    render_model_download_progress()
 
 
 if __name__ == "__main__":

--- a/frontend/src/config/constants.py
+++ b/frontend/src/config/constants.py
@@ -21,6 +21,8 @@ TEXTS = {
             "generate_button": "Generate",
             "spinner_text": "Generating task...",
             "no_tasks_text": "No tasks to display.",
+            "model_download_text": "Downloading model {model}...",
+            "model_download_error": "Failed to download model {model}.",
         },
         "help": {
             "title": "Why other tools don't help you!",
@@ -57,6 +59,8 @@ TEXTS = {
             "generate_button": "Generiere",
             "spinner_text": "Aufgabe wird generiert...",
             "no_tasks_text": "Keine Aufgaben zum Anzeigen.",
+            "model_download_text": "Modell {model} wird heruntergeladen...",
+            "model_download_error": "Herunterladen des Modells {model} fehlgeschlagen.",
         },
         "help": {
             "title": "Warum andere Tools dir nicht helfen!",
@@ -93,6 +97,8 @@ TEXTS = {
             "generate_button": "Generar",
             "spinner_text": "Generando tarea...",
             "no_tasks_text": "No hay tareas para mostrar.",
+            "model_download_text": "Descargando el modelo {model}...",
+            "model_download_error": "Error al descargar el modelo {model}.",
         },
         "help": {
             "title": "¡Por qué otras herramientas no te ayudan!",
@@ -129,6 +135,8 @@ TEXTS = {
             "generate_button": "Générer",
             "spinner_text": "Génération de tâche...",
             "no_tasks_text": "Aucune tâche à afficher.",
+            "model_download_text": "Téléchargement du modèle {model}...",
+            "model_download_error": "Échec du téléchargement du modèle {model}.",
         },
         "help": {
             "title": "Pourquoi les autres outils ne vous aident pas !",

--- a/frontend/src/config/state.py
+++ b/frontend/src/config/state.py
@@ -11,6 +11,8 @@ def configure_states():
     st.session_state.setdefault("old_page_number", 1)
     st.session_state.setdefault("show_help_dialog", False)
     st.session_state.setdefault("show_settings_dialog", False)
+    st.session_state.setdefault("model_ready", True)
+    st.session_state.setdefault("model_download_status", None)
 
     backend_settings = load_settings()
     if backend_settings:

--- a/frontend/src/ui/page_setup.py
+++ b/frontend/src/ui/page_setup.py
@@ -40,6 +40,9 @@ def setup_custom_styles():
             margin-top: 0.3rem !important;
             margin-bottom: -0.3rem !important;
         }
+        [data-testid="stProgressBarTrack"] > div {
+            background-color: #FF4B4B !important;
+        }
         #MainMenu, footer, header {
             visibility: hidden !important;
         }

--- a/frontend/src/ui/rendering.py
+++ b/frontend/src/ui/rendering.py
@@ -1,5 +1,6 @@
 import streamlit as st
 from utils.tasks_api import create_task, set_task_as_favorite, get_task_count
+from utils.models_api import get_model_status
 from utils.text import get_local_text, get_generic_text
 from utils.time import format_time
 
@@ -17,6 +18,7 @@ def render_header_elements():
             "generate_button",
             local_text["main"]["generate_button"],
             rerun_on_click=True,
+            disabled=not st.session_state.get("model_ready", True),
         )
 
     with col2:
@@ -36,9 +38,12 @@ def render_header_elements():
         st.session_state.loading_spinner = st.container()
 
 
-def _render_button(key, label, rerun_on_click=False):
+def _render_button(key, label, rerun_on_click=False, disabled=False):
     if st.button(
-        label, disabled=st.session_state.running, key=key, use_container_width=True
+        label,
+        disabled=st.session_state.running or disabled,
+        key=key,
+        use_container_width=True,
     ):
         if rerun_on_click:
             st.session_state.running = True
@@ -151,3 +156,40 @@ def render_pagination():
     if selection and int(selection) != current_page:
         st.session_state.page_number = int(selection)
         st.rerun()
+
+
+def render_model_download_progress():
+    """Show model download progress, isolated in a fragment so only this
+    section re-renders while downloading instead of the whole page."""
+    if st.session_state.get("model_ready", True):
+        return
+    _poll_model_download()
+
+
+@st.fragment(run_every=1)
+def _poll_model_download():
+    model = st.session_state.settings["MODEL"]
+    status = get_model_status(model)
+    if status is None:
+        return
+
+    st.session_state.model_download_status = status
+
+    if status.get("status") == "ready":
+        st.session_state.model_ready = True
+        st.rerun()
+        return
+
+    local_text = get_local_text()["main"]
+
+    if status.get("status") == "error":
+        st.error(local_text["model_download_error"].format(model=model))
+        return
+
+    completed = status.get("completed", 0)
+    total = status.get("total", 0)
+    progress = completed / total if total else 0.0
+
+    st.progress(
+        progress, text=local_text["model_download_text"].format(model=model)
+    )

--- a/frontend/src/utils/models_api.py
+++ b/frontend/src/utils/models_api.py
@@ -1,0 +1,43 @@
+import streamlit as st
+from config.constants import BACKEND_URL
+from utils.http import api_request
+
+
+def sync_model_status():
+    """Refresh readiness of the currently selected model and kick off a download if needed."""
+    model = st.session_state.settings["MODEL"]
+    status = get_model_status(model)
+
+    if status is None:
+        # Backend unreachable: don't lock the UI on a status we can't verify.
+        st.session_state.model_ready = True
+        st.session_state.model_download_status = None
+        return
+
+    st.session_state.model_download_status = status
+    st.session_state.model_ready = status.get("status") == "ready"
+
+    if status.get("status") == "not_downloaded":
+        start_model_pull(model)
+
+
+def get_model_status(model: str):
+    """Fetch the readiness status of a model from the backend."""
+    response = api_request(
+        "get",
+        f"{BACKEND_URL}/models/status",
+        "checking model status",
+        params={"model": model},
+    )
+    return response.json() if response is not None else None
+
+
+def start_model_pull(model: str):
+    """Ask the backend to start downloading a model."""
+    response = api_request(
+        "post",
+        f"{BACKEND_URL}/models/pull",
+        "starting model download",
+        json={"model": model},
+    )
+    return response.json() if response is not None else None

--- a/frontend/test/test_models_api.py
+++ b/frontend/test/test_models_api.py
@@ -1,0 +1,92 @@
+from unittest.mock import patch, MagicMock
+import requests
+
+from utils.models_api import get_model_status, start_model_pull, sync_model_status
+
+
+@patch("utils.models_api.BACKEND_URL", "http://localhost:8000")
+@patch("utils.http.requests.get")
+def test_get_model_status_success(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"status": "ready"}
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    result = get_model_status("some-model")
+
+    assert result == {"status": "ready"}
+    mock_get.assert_called_once_with(
+        "http://localhost:8000/models/status", params={"model": "some-model"}
+    )
+
+
+@patch("utils.http.handle_request_error")
+@patch(
+    "utils.http.requests.get",
+    side_effect=requests.exceptions.RequestException("Network error"),
+)
+def test_get_model_status_failure(mock_get, mock_error_handler):
+    result = get_model_status("some-model")
+    assert result is None
+    mock_error_handler.assert_called_once()
+
+
+@patch("utils.models_api.BACKEND_URL", "http://localhost:8000")
+@patch("utils.http.requests.post")
+def test_start_model_pull_success(mock_post):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"status": "downloading"}
+    mock_response.raise_for_status.return_value = None
+    mock_post.return_value = mock_response
+
+    result = start_model_pull("some-model")
+
+    assert result == {"status": "downloading"}
+    mock_post.assert_called_once_with(
+        "http://localhost:8000/models/pull", json={"model": "some-model"}
+    )
+
+
+@patch("utils.models_api.st")
+@patch("utils.models_api.start_model_pull")
+@patch("utils.models_api.get_model_status")
+def test_sync_model_status_marks_ready(mock_status, mock_pull, mock_st):
+    mock_st.session_state.settings = {"MODEL": "some-model"}
+    mock_status.return_value = {"status": "ready"}
+
+    sync_model_status()
+
+    assert mock_st.session_state.model_ready is True
+    assert mock_st.session_state.model_download_status == {"status": "ready"}
+    mock_pull.assert_not_called()
+
+
+@patch("utils.models_api.st")
+@patch("utils.models_api.start_model_pull")
+@patch("utils.models_api.get_model_status")
+def test_sync_model_status_triggers_pull_when_not_downloaded(
+    mock_status, mock_pull, mock_st
+):
+    mock_st.session_state.settings = {"MODEL": "some-model"}
+    mock_status.return_value = {"status": "not_downloaded"}
+
+    sync_model_status()
+
+    assert mock_st.session_state.model_ready is False
+    mock_pull.assert_called_once_with("some-model")
+
+
+@patch("utils.models_api.st")
+@patch("utils.models_api.start_model_pull")
+@patch("utils.models_api.get_model_status")
+def test_sync_model_status_fails_open_when_backend_unreachable(
+    mock_status, mock_pull, mock_st
+):
+    mock_st.session_state.settings = {"MODEL": "some-model"}
+    mock_status.return_value = None
+
+    sync_model_status()
+
+    assert mock_st.session_state.model_ready is True
+    assert mock_st.session_state.model_download_status is None
+    mock_pull.assert_not_called()

--- a/frontend/test/test_rendering.py
+++ b/frontend/test/test_rendering.py
@@ -1,3 +1,4 @@
+import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -7,6 +8,25 @@ from ui.rendering import (
     render_pagination,
     render_loading_spinner,
 )
+
+
+def _passthrough_fragment(*args, **kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+@pytest.fixture
+def rendering_module():
+    """ui.rendering applies @st.fragment(...) at import time, so st.fragment
+    must already be a passthrough decorator before the module is (re)imported."""
+    with patch("streamlit.fragment", side_effect=_passthrough_fragment):
+        sys.modules.pop("ui.rendering", None)
+        import ui.rendering as module
+
+        yield module
+    sys.modules.pop("ui.rendering", None)
 
 
 @pytest.fixture
@@ -24,6 +44,7 @@ def fake_session_state(monkeypatch):
                 "LANGUAGE": "English",
                 "TIMEZONE": "Europe/Berlin",
                 "PAGE_SIZE": 5,
+                "MODEL": "test-model",
             },
             "feedback_filter": False,
             "page_number": 1,
@@ -135,3 +156,82 @@ def test_render_loading_spinner_noop_when_not_running(fake_session_state):
 
         mock_create_task.assert_not_called()
         mock_st.empty.assert_called_once()
+
+
+def test_render_model_download_progress_noop_when_ready(
+    fake_session_state, rendering_module
+):
+    fake_session_state["model_ready"] = True
+
+    with patch("ui.rendering.st") as mock_st, patch(
+        "ui.rendering.get_model_status"
+    ) as mock_status:
+        mock_st.session_state = fake_session_state
+        rendering_module.render_model_download_progress()
+
+        mock_status.assert_not_called()
+        mock_st.progress.assert_not_called()
+
+
+def test_render_model_download_progress_shows_bar_while_downloading(
+    fake_session_state, rendering_module
+):
+    fake_session_state["model_ready"] = False
+
+    with patch("ui.rendering.st") as mock_st, patch(
+        "ui.rendering.get_model_status",
+        return_value={"status": "downloading", "completed": 5, "total": 10},
+    ):
+        mock_st.session_state = fake_session_state
+        rendering_module.render_model_download_progress()
+
+        mock_st.progress.assert_called_once()
+        assert mock_st.progress.call_args[0][0] == 0.5
+        mock_st.rerun.assert_not_called()
+        assert fake_session_state["model_ready"] is False
+
+
+def test_render_model_download_progress_shows_error(
+    fake_session_state, rendering_module
+):
+    fake_session_state["model_ready"] = False
+
+    with patch("ui.rendering.st") as mock_st, patch(
+        "ui.rendering.get_model_status", return_value={"status": "error"}
+    ):
+        mock_st.session_state = fake_session_state
+        rendering_module.render_model_download_progress()
+
+        mock_st.error.assert_called_once()
+        mock_st.rerun.assert_not_called()
+
+
+def test_render_model_download_progress_reruns_once_ready(
+    fake_session_state, rendering_module
+):
+    fake_session_state["model_ready"] = False
+
+    with patch("ui.rendering.st") as mock_st, patch(
+        "ui.rendering.get_model_status", return_value={"status": "ready"}
+    ):
+        mock_st.session_state = fake_session_state
+        rendering_module.render_model_download_progress()
+
+        assert fake_session_state["model_ready"] is True
+        mock_st.rerun.assert_called_once()
+        mock_st.progress.assert_not_called()
+
+
+def test_render_model_download_progress_noop_when_backend_unreachable(
+    fake_session_state, rendering_module
+):
+    fake_session_state["model_ready"] = False
+
+    with patch("ui.rendering.st") as mock_st, patch(
+        "ui.rendering.get_model_status", return_value=None
+    ):
+        mock_st.session_state = fake_session_state
+        rendering_module.render_model_download_progress()
+
+        mock_st.progress.assert_not_called()
+        mock_st.rerun.assert_not_called()

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^26.1.0"
       }
     },

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^26.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- Selecting a model that isn't pulled yet used to fail task generation with a generic 500 once the request reached Ollama. Now the backend tracks pull progress in the background (`GET /models/status`, `POST /models/pull`) and returns 409 while a model isn't ready.
- The frontend shows a live progress bar and disables the Generate button until the model is ready, polled via an isolated `st.fragment` so the rest of the page (and any open dialog) doesn't flicker on every refresh.
- Bumped gunicorn's timeout to 300s so loading larger models doesn't get the worker SIGKILLed mid-request (was hitting the default 30s timeout).
- Fixed a bug where Ollama's trailing pull-status lines (`verifying sha256 digest`, `writing manifest`) omit `completed`/`total`, which was resetting the progress bar to 0 right before completion.
- Matched the progress bar's color to the rest of the theme (Streamlit hardcodes a blue fill for `st.progress` regardless of theme).
- Bumped `@playwright/test` to 1.61.1 to drop a `DEP0205 module.register` deprecation warning under Node 26 (newer Playwright prefers `module.registerHooks` when available).

## Test plan
- [x] Backend: 42 tests pass (`uv run pytest test/`), including new coverage for pull/status tracking, the 409 readiness guard, and the trailing-message progress bug
- [x] Frontend: 46 tests pass (`uv run pytest test/`), including new coverage for the fragment-based polling and disabled-button states
- [x] Verified live in browser via Playwright: dialog closes on Save and stays closed through an entire download, Generate button disabled/enabled correctly, progress bar color matches theme, deprecation warning gone
- [x] Verified deepseek-v2:16b and other larger models load successfully with the gunicorn timeout fix